### PR TITLE
fix: Redirect URIs invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ spotify 歌词滚动窗口
 
 1. Get your own spotify client id and secret from [spotify developer](https://developer.spotify.com/dashboard/). 从spotify开发者面板获取您的app id和密码
 2. Create a developer app and edit its setting. 打开新创建的应用并且编辑设置
-3. add ```http://localhost:8888/callback``` to your **Redirect URIs** setting. 将该网址加入此设置项
+3. add ```http://127.0.0.1:8888/callback``` to your **Redirect URIs** setting. 将该网址加入此设置项
 4. Run the program and open setting page. Put your client_id and client_secret in it. 运行程序并打开设置窗口输入您获取到的app id以及密码
 5. Click the user icon in the window to complete the authorization. 点击窗口的用户图标完成授权
 6. click the sure and enjoy it! 😋 按下确定，然后试试！

--- a/SpotifyLyricWindow/common/api/user_api/user_auth.py
+++ b/SpotifyLyricWindow/common/api/user_api/user_auth.py
@@ -82,7 +82,7 @@ class SpotifyUserAuth:
         url_param = {
             "client_id": self.client_id,
             'response_type': 'code',
-            'redirect_uri': 'http://localhost:8888/callback',
+            'redirect_uri': 'http://127.0.0.1:8888/callback',
             'scope': self._generate_scope_data(),
             'state': self.state
         }
@@ -123,7 +123,7 @@ class SpotifyUserAuth:
             raise NoAuthError("请先完成用户验证")
         form = {
             "code": self.auth_code,
-            "redirect_uri": "http://localhost:8888/callback",
+            "redirect_uri": "http://127.0.0.1:8888/callback",
             "grant_type": 'authorization_code'
         }
         self.user_token_info = requests.post(self.AUTH_TOKEN_URL, data=form, headers=self.auth_client_header, proxies=self.proxy).json()


### PR DESCRIPTION
Beginning on the 9th of April 2025, the Spotify Developer Portal will no longer allow the use of `localhost` as loopback address, so we need to change it to `127.0.0.1`

https://developer.spotify.com/documentation/web-api/concepts/redirect_uri